### PR TITLE
scripts: modify bash shebang for portability

### DIFF
--- a/import-mod.sh
+++ b/import-mod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright (C) 2022 Divyanshu-Modi <divyan.m05@gmail.com>
 # based on <pig.priv@gmail.com> module importer
 

--- a/regen.sh
+++ b/regen.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
  # Script For Regenerating Defconfig of Android arm64 Kernel
  #


### PR DESCRIPTION
Different *nix distributions install `bash` in different locations, and using `/usr/bin/env` is a workaround for running the `bash` found on the `PATH`.