### PR TITLE
scripts: Remove useless call to `cmd` at success message print

### DIFF
--- a/import-mod.sh
+++ b/import-mod.sh
@@ -91,11 +91,11 @@ exfat_import() {
 if [ "$option" = 'u' ]; then
 	msg="fs/exfat: Update from arter97/exfat-linux"
 	importer "UPDATE" "fs/exfat" https://github.com/arter97/exfat-linux master "$msg"
-	success "Successfully updated exFAT" "$cmd"
+	success "Successfully updated exFAT"
 else
 	msg="fs: Import exFAT driver"
 	importer "SUBTREE" "fs/exfat" https://github.com/arter97/exfat-linux master "$msg"
-	success "Successfully imported exFAT" "$cmd"
+	success "Successfully imported exFAT"
 fi
 }
 
@@ -104,11 +104,11 @@ mainline_exfat_import() {
 if [ "$option" = 'u' ]; then
 	msg="fs/exfat: Update from namjaejeon/linux-exfat-oot"
 	importer "UPDATE" "fs/exfat" https://github.com/namjaejeon/linux-exfat-oot master "$msg"
-	success "Successfully updated mainline exFAT" "$cmd"
+	success "Successfully updated mainline exFAT"
 else
 	msg="fs: Import mainline exFAT driver"
 	importer "SUBTREE" "fs/exfat" https://github.com/namjaejeon/linux-exfat-oot master "$msg"
-	success "Successfully imported mainline exFAT" "$cmd"
+	success "Successfully imported mainline exFAT"
 fi
 }
 
@@ -117,11 +117,11 @@ kprofiles_import() {
 if [ "$option" = 'u' ]; then
 	msg="kprofiles: Update from dakkshesh07/Kprofiles"
 	importer "UPDATE" "drivers/misc/kprofiles" https://github.com/dakkshesh07/Kprofiles main "$msg"
-	success "Successfully updated Kprofiles" "$cmd"
+	success "Successfully updated Kprofiles"
 else
 	msg="drivers/misc: Introduce KernelSpace Profile Modes"
 	importer "SUBTREE" "drivers/misc/kprofiles" https://github.com/dakkshesh07/Kprofiles main "$msg"
-	success "Successfully imported Kprofiles" "$cmd"
+	success "Successfully imported Kprofiles"
 fi
 }
 


### PR DESCRIPTION
Prints a useless "m" for exfat and kprofiles. Not needed here at all.