### PR TITLE
scripts: Avoid showing unavailable merge options for import

### DIFF
--- a/import-mod.sh
+++ b/import-mod.sh
@@ -274,7 +274,7 @@ init() {
 					read -rp "Target tag / branch: " br
 				fi
 				read -rp "Import (i) / Update (u): " option
-				if [ "$option" != u ]; then
+				if [[ "$option" != u && "$num" -lt '12' ]]; then
 					read -rp "Target cmd: merge (m) subtree (s) " cmd
 				else
 					cmd=m


### PR DESCRIPTION
The import functions of exfat and kprofiles use "subtree" to import and can't use "merge". It is pointless to show merge options for them during import and ask if the user want to use merge or subtree.

Signed-off-by: Tashfin Shakeer Rhythm <tashfinshakeerrhythm@gmail.com>